### PR TITLE
Add web.config to serve static .json files on Azure

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<configuration>
+    <system.webServer>
+        <staticContent>
+            <mimeMap fileExtension=".json" mimeType="application/json" />
+     </staticContent>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
A static .json file will 404 on Windows Azure because
the MIME Type is not set by default.